### PR TITLE
Fix Paths/Skipmaster/Ability_WorldTeleport.cs

### DIFF
--- a/1.3/Source/VanillaPsycastsExpanded/Paths/Skipmaster/Ability_WorldTeleport.cs
+++ b/1.3/Source/VanillaPsycastsExpanded/Paths/Skipmaster/Ability_WorldTeleport.cs
@@ -51,12 +51,11 @@ public class Ability_WorldTeleport : Ability
 
     public override bool CanHitTargetTile(GlobalTargetInfo target)
     {
-        Caravan caravan = this.pawn.GetCaravan();
-        if (caravan is { ImmobilizedByMass: true }) return false;
-        Caravan caravan1 = target.WorldObject as Caravan;
-
-        return (caravan == null || caravan != caravan1) && (this.ShouldEnterMap(target) || (caravan1 != null && caravan1.Faction == this.pawn.Faction)) &&
-               base.CanHitTargetTile(target);
+        int distanceBetweenTargets = Find.WorldGrid.TraversalDistanceBetween((this.CasterPawn.GetCaravan() != null) ? (this.CasterPawn.GetCaravan().Tile) : (this.Caster.Map.Tile), target.Tile);
+            if (distanceBetweenTargets < this.GetRangeForPawn() + 1 && distanceBetweenTargets > -1)
+                return true;
+            else
+                return false;
     }
 
     public override bool IsEnabledForPawn(out string reason)
@@ -162,8 +161,9 @@ public class Ability_WorldTeleport : Ability
         base.Cast(targets);
     }
 
-    public override void DrawHighlight(LocalTargetInfo target)
+    public override void GizmoUpdateOnMouseover()
     {
-        GenDraw.DrawRadiusRing(this.pawn.Position, this.GetRadiusForPawn(), Color.blue);
+        float radiusForPawn = this.GetRadiusForPawn();
+        GenDraw.DrawRadiusRing(this.pawn.Position, radiusForPawn, this.def.radiusRingColor);
     }
 }


### PR DESCRIPTION
The function DrawHighlight() doesn't work for some reason, but using GizmoUpdateOnMouseover() works just fine.
I don't understand what CanHitTargetTile() is suppose to do when "Ability_WorldTeleportNight" straight up overrides the value depending on the night cycle.
My code for CanHitTargetTile() checks is the mouse in range of the ability and prevents teleporting to the current location (it can happen with night skip now because of the override).
Also for a balancing issue. I think that range 9999 for night skip is way too overpowered, since the player can jump right into the ship with it.
Also, odd thing, the far skip ability allows teleporting only to the home location (colony). My code fixes that.
Cheers guys :)